### PR TITLE
Add compatibility for Craft 3 and PHP 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     }
   ],
   "require": {
-    "php": ">=8.0",
-    "craftcms/cms": "^4.0.0"
+    "php": ">=7.0",
+    "craftcms/cms": "^3.0|^4.0"
   },
   "repositories": [
     {

--- a/src/Cookiebot.php
+++ b/src/Cookiebot.php
@@ -2,7 +2,6 @@
 
 namespace humandirect\cookiebot;
 
-use craft\base\Model;
 use craft\base\Plugin;
 use craft\web\twig\variables\CraftVariable;
 
@@ -64,7 +63,7 @@ class Cookiebot extends Plugin
     /**
      * @inheritdoc
      */
-    protected function createSettingsModel(): ?Model
+    protected function createSettingsModel(): Settings
     {
         return new Settings();
     }

--- a/src/services/CookiebotService.php
+++ b/src/services/CookiebotService.php
@@ -15,7 +15,7 @@ use humandirect\cookiebot\Cookiebot;
  */
 class CookiebotService extends Component
 {
-    private const COOKIE_NAME = 'CookieConsent';
+    const COOKIE_NAME = 'CookieConsent';
 
     /**
      * @var \stdClass|null


### PR DESCRIPTION
This PR adds compatibility for Craft 3 and PHP 7.0 back in.

- Makes the return type  more specific.
- Loosens requirements.
- Removes constant visibility to support PHP 7.0.